### PR TITLE
Reduce spam potential of logging line

### DIFF
--- a/base_local_planner/src/trajectory_planner.cpp
+++ b/base_local_planner/src/trajectory_planner.cpp
@@ -510,7 +510,7 @@ namespace base_local_planner{
     if(cost >= 0) {
       return true;
     }
-    ROS_WARN("Invalid Trajectory %f, %f, %f, cost: %f", vx_samp, vy_samp, vtheta_samp, cost);
+    ROS_DEBUG("Invalid Trajectory %f, %f, %f, cost: %f", vx_samp, vy_samp, vtheta_samp, cost);
 
     //otherwise the check fails
     return false;


### PR DESCRIPTION
Just a follow up of #1027. As was made clear in that PR,  throttling was not the right approach to handle this as the line could potentially produce different information on each entry. 

Maybe at a higher level a WARN would be totally justified, if no valid trajectories are found after evaluating multiple ones, (think DWA, etc), but evaluating a single trajectory and finding it to be invalid could is, in many cases, completely normal as part of a larger search.
